### PR TITLE
Add commit authors

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -33,7 +33,7 @@ const getCommitMessages = async (repo, sha) => {
       break;
     }
   }
-  return commits.slice(0, index).map(c => `- [${c.commit.message.split("\n\n")[0]}](${c.html_url})`)
+  return commits.slice(0, index).map(c => `- [${c.commit.message.split("\n\n")[0]}](${c.html_url}) by ${c.commit.author.name}`)
 }
 
 const getHeadSha = async (repo) => {

--- a/index.js
+++ b/index.js
@@ -18,7 +18,7 @@ const getCommitMessages = async (repo, sha) => {
       break;
     }
   }
-  return commits.slice(0, index).map(c => `- [${c.commit.message.split("\n\n")[0]}](${c.html_url})`)
+  return commits.slice(0, index).map(c => `- [${c.commit.message.split("\n\n")[0]}](${c.html_url}) by ${c.commit.author.name}`)
 }
 
 const getHeadSha = async (repo) => {


### PR DESCRIPTION
As we're more developers, add the commit authors to the PR to make it easier to check with developers before deploying to production. Use the full name instead of mentioning people to avoid notifications

![Screen Shot 2020-11-17 at 10 00 48](https://user-images.githubusercontent.com/295709/99406565-06530980-28bc-11eb-9861-8a4f57b1c8b0.png)