### PR TITLE
Trim Terraform prod version

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -152,7 +152,7 @@ async function isNotLatestTerraformVersion() {
     ".github/workflows/infrastructure_version.txt"
   );
 
-  const prodVersion = Base64.decode(prodWorkflow.content);
+  const prodVersion = Base64.decode(prodWorkflow.content).trim();
   const latestVersion = (await getLatestTag("notification-terraform")).replace(
     "v",
     ""

--- a/index.js
+++ b/index.js
@@ -137,7 +137,7 @@ async function isNotLatestTerraformVersion() {
     ".github/workflows/infrastructure_version.txt"
   );
 
-  const prodVersion = Base64.decode(prodWorkflow.content);
+  const prodVersion = Base64.decode(prodWorkflow.content).trim();
   const latestVersion = (await getLatestTag("notification-terraform")).replace(
     "v",
     ""


### PR DESCRIPTION
Revises https://github.com/cds-snc/notification-pr-bot/pull/14

The production version from https://github.com/cds-snc/notification-terraform/blob/main/.github/workflows/infrastructure_version.txt includes a newline at the end, making the string comparison falsy. Clean the string to fix that.