### PR TITLE
feat: figure out the main branch automatically

### DIFF
--- a/index.js
+++ b/index.js
@@ -18,27 +18,22 @@ const PROJECTS = [
   {
     name: "notification-api",
     ecrName: "notify-api",
-    mainBranch: "master",
   },
   {
     name: "notification-admin",
     ecrName: "notify-admin",
-    mainBranch: "master",
   },
   {
     name: "notification-document-download-api",
     ecrName: "notify-document-download-api",
-    mainBranch: "master",
   },
   {
     name: "notification-document-download-frontend",
     ecrName: "notify-document-download-frontend",
-    mainBranch: "master",
   },
   {
     name: "notification-documentation",
     ecrName: "notify-documentation",
-    mainBranch: "main",
   },
 ];
 
@@ -67,11 +62,15 @@ const getCommitMessages = async (repo, sha) => {
     );
 };
 
-const getHeadSha = async (repo, branch = "master") => {
+const getHeadSha = async (repo) => {
+  const { data: repoDetails } = await octokit.repos.get({
+    owner: GH_CDS,
+    repo,
+  });
   const { data: repoBranch } = await octokit.repos.getBranch({
     owner: GH_CDS,
     repo,
-    branch,
+    branch: repoDetails.default_branch,
   });
   return repoBranch.commit.sha;
 };
@@ -194,7 +193,7 @@ async function createPR(
   newReleaseContentBlob
 ) {
   const branchName = `release-${new Date().getTime()}`;
-  const manifestsSha = await getHeadSha("notification-manifests", "main");
+  const manifestsSha = await getHeadSha("notification-manifests");
   const logs = await buildLogs(projects);
 
   const ref = await octokit.git.createRef({
@@ -240,10 +239,7 @@ async function hydrateWithSHAs(releaseConfig, projects) {
       const matchingProject = projects.find((project) =>
         image.newName.includes(project.ecrName)
       );
-      matchingProject.headSha = await getHeadSha(
-        matchingProject.name,
-        matchingProject.mainBranch
-      );
+      matchingProject.headSha = await getHeadSha(matchingProject.name);
       matchingProject.headUrl = getLatestImageUrl(
         matchingProject.ecrName,
         matchingProject.headSha


### PR DESCRIPTION
Rely on the REST API to find out the default branch rather than relying on master/main. Will help if we rename our branches to `main` down the road.

Related to https://github.com/cds-snc/notification-api/issues/1289