### PR TITLE
rebuild distribution

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -241,12 +241,6 @@ const PROJECTS = [
     ecrName: "notify-document-download-api",
   },
   {
-    repoName: "notification-document-download-frontend",
-    manifestFile: "env/production/kustomization.yaml",
-    ecrUrl: AWS_ECR_URL,
-    ecrName: "notify-document-download-frontend",
-  },
-  {
     repoName: "notification-documentation",
     manifestFile: "env/production/kustomization.yaml",
     ecrUrl: AWS_ECR_URL,


### PR DESCRIPTION
# Summary | Résumé

I didn't do an `npm run build` when I removed the document-download-frontend` code from pr-bot [here](https://github.com/cds-snc/notification-pr-bot/pull/27) 😞 . So on Thursday when I r[emoved the code from manifest](https://github.com/cds-snc/notification-manifests/pull/1200), pr-bot started failing when looking for it.
