### PR TITLE
Fix: update api lambda image

### DIFF
--- a/github.js
+++ b/github.js
@@ -39,15 +39,14 @@ async function closePRs() {
 }
 
 async function createPR(
-  projects,
+  projects, projects_lambdas,
   issueContent,
-  releaseContentArray,
+  changesToHelmfile, changesToLambdaFiles,
 
 ) {
   const branchName = `release-${new Date().getTime()}`;
   const manifestsSha = await getHeadSha("notification-manifests");
   const logs = await buildLogs(projects);
-  const isHelmfile = 'false';
 
   const ref = await octokit.rest.git.createRef({
     owner: GH_CDS,
@@ -56,34 +55,46 @@ async function createPR(
     sha: manifestsSha,
   });
 
-  const manifestUpdates = projects
+  const helmManifestUpdates = projects
     .map((project) => {
       return `${project.repoName}:${project.shortSha}`;
     })
     .join(" and ");
 
-    var prPrefix = ""
-
-  prPrefix = "HELMFILE" 
-  for (const { helmfileOverride, releaseContent, newReleaseContentBlob } of releaseContentArray) {
+  for (const { helmfileOverride, releaseContent, newReleaseContentBlob } of changesToHelmfile) {
     await octokit.rest.repos.createOrUpdateFileContents({
       owner: GH_CDS,
       repo: "notification-manifests",
       branch: branchName,
       sha: releaseContent.sha,
       path: helmfileOverride,
-      message: `Updated manifests to ${manifestUpdates}`,
+      message: `Updated manifests to ${helmManifestUpdates}`,
       content: newReleaseContentBlob,
     })
   }
 
+  const lambdaManifestUpdates = projects_lambdas
+    .map((project) => {
+      return `${project.repoName}:${project.shortSha}`;
+    })
+    .join(" and ");
 
-
+  for (const { manifestFile, releaseContent, newReleaseContentBlob } of changesToLambdaFiles) {
+    await octokit.rest.repos.createOrUpdateFileContents({
+      owner: GH_CDS,
+      repo: "notification-manifests",
+      branch: branchName,
+      sha: releaseContent.sha,
+      path: manifestFile,
+      message: `Updated manifests to ${lambdaManifestUpdates}`,
+      content: newReleaseContentBlob,
+    })
+  }
 
   const pr = await octokit.rest.pulls.create({
     owner: GH_CDS,
     repo: "notification-manifests",
-    title: `[AUTO-PR] ${prPrefix} - Automatically generated new release ${new Date().toISOString()}`,
+    title: `[TEST DO NOT MERGE] - Automatically generated new release ${new Date().toISOString()}`,
     head: branchName,
     base: "main",
     body: issueContent.replace(

--- a/index.js
+++ b/index.js
@@ -8,13 +8,6 @@ const PROJECTS = [
     repoName: "notification-api",
     helmfileOverride: "helmfile/overrides/production.env",
     helmfileTagKey: "API_DOCKER_TAG",
-    ecrUrl: "${PRODUCTION_ECR_ACCOUNT}.dkr.ecr.ca-central-1.amazonaws.com/notify",
-    ecrName: "api-lambda",
-  },
-  {
-    repoName: "notification-api",
-    helmfileOverride: "helmfile/overrides/production.env",
-    helmfileTagKey: "API_DOCKER_TAG",
     ecrUrl: AWS_ECR_URL,
     ecrName: "notify-api",
   },
@@ -39,17 +32,28 @@ const PROJECTS = [
     ecrUrl: AWS_ECR_URL,
     ecrName: "notify-documentation",
   },
+];
+
+const PROJECTS_LAMBDAS = [
+  {
+    repoName: "notification-api",
+    manifestFile: ".github/workflows/merge_to_main_production.yaml",
+    ecrUrl: "${PRODUCTION_ECR_ACCOUNT}.dkr.ecr.ca-central-1.amazonaws.com/notify",
+    ecrName: "api-lambda",
+  },
   // {
   //   repoName: "notification-lambdas",
+  //   manifestFile: ".github/workflows/merge_to_main_production.yaml",
   //   ecrUrl: "${PRODUCTION_ECR_ACCOUNT}.dkr.ecr.ca-central-1.amazonaws.com/notify",
   //   ecrName: "system_status",
   // },
   // {
   //   repoName: "notification-lambdas",
+  //   manifestFile: ".github/workflows/merge_to_main_production.yaml",
   //   ecrUrl: "${PRODUCTION_ECR_ACCOUNT}.dkr.ecr.ca-central-1.amazonaws.com/notify",
   //   ecrName: "heartbeat",
   // },
-];
+]
 
 // Logic ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
@@ -63,15 +67,17 @@ function getLatestImageUrl(projects, projectName, headSha) {
 }
 
 function getSha(project, content) {
-
   const helmfileRe = new RegExp(`${project.helmfileTagKey}: "(.*?)"`, "g")
-  result = content.match(helmfileRe)[0]
+  const result = content.match(helmfileRe)[0]
   const tagShaRe = new RegExp(`"(.*?)"`, "g")
-  tag = result.match(tagShaRe)[0]
+  var tag = result.match(tagShaRe)[0]
   tag = tag.replaceAll("\"","");
-  
   return tag;
 
+}
+
+function getLambdaSha(imageName) {
+  return imageName.split(":").slice(-1)[0];
 }
 
 async function hydrateWithSHAs(projects) {
@@ -83,11 +89,6 @@ async function hydrateWithSHAs(projects) {
         projects,
         project.ecrName,
         project.headSha
-      );
-
-      const releaseContent = await getContents(
-        "notification-manifests",
-        project.helmfileOverride
       );
 
       // Patch the helmfile tags
@@ -105,6 +106,31 @@ async function hydrateWithSHAs(projects) {
   );
 }
 
+async function hydrateLambdasWithSHAs(projects) {
+  return await Promise.all(
+    projects.map(async (project) => {
+      project.headSha = await getHeadSha(project.repoName);
+      project.shortSha = shortSha(project.headSha)
+      project.headUrl = getLatestImageUrl(
+        projects,
+        project.ecrName,
+        project.headSha
+      );
+
+      const releaseContent = await getContents(
+        "notification-manifests",
+        project.manifestFile
+      );
+
+      const originalFileContents = Base64.decode(releaseContent.content)
+      const re = new RegExp(`${project.ecrName}:\\S*`, "g");
+      project.oldUrl = originalFileContents.match(re)[0]
+      project.oldSha = getLambdaSha(project.oldUrl);
+      return project;
+    })
+  );
+}
+
 function updateHelmfileSha(content,project) {
   
   let re = new RegExp(String.raw`${project.helmfileTagKey}: "(.*?)"`, "g");
@@ -112,9 +138,13 @@ function updateHelmfileSha(content,project) {
   return content.replace(re, `${project.helmfileTagKey}: "${shortSha(project.headSha)}"`);
 }
 
+function updateLambdaSha(content, project) {
+  return content.replace(`${project.ecrName}:${project.oldSha}`, `${project.ecrName}:${shortSha(project.headSha)}`)
+}
+
 // HELMFILE ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-async function runHelmfile(projects) {
+async function main(projects, projects_lambdas) {
   const prTemplate = await getContents(
     "notification-manifests",
     ".github/PULL_REQUEST_TEMPLATE.md"
@@ -122,6 +152,7 @@ async function runHelmfile(projects) {
   const issueContent = Base64.decode(prTemplate.content);
 
   await hydrateWithSHAs(projects);
+  await hydrateLambdasWithSHAs(projects_lambdas);
 
   const reducer = (previous, project) => ({ ...previous, [project.helmfileOverride]: (previous[project.helmfileOverride] || []).concat(project) })
   const projectsForFiles = projects.reduce(reducer, {})
@@ -144,17 +175,42 @@ async function runHelmfile(projects) {
 
     return { helmfileOverride, newReleaseContentBlob, releaseContent, fileHasChanged }
   })
+
+  const lambdaReducer = (previous, project) => ({ ...previous, [project.manifestFile]: (previous[project.manifestFile] || []).concat(project) })
+  const lambdaProjectsForFiles = projects_lambdas.reduce(lambdaReducer, {})
+
+  var changesToLambdaFiles = Object.entries(lambdaProjectsForFiles).map(async ([manifestFile, projectsForFile]) => {
+
+    const releaseContent = await getContents(
+      "notification-manifests",
+      manifestFile
+    );
+
+    var fileContents = Base64.decode(releaseContent.content)
+    projectsForFile.forEach((project) => {
+      fileContents = updateLambdaSha(fileContents, project)
+    })
+
+    const newReleaseContentBlob = Base64.encode(fileContents);
+    const fileHasChanged = newReleaseContentBlob.trim() != releaseContent.content.trim()
+
+    return { manifestFile, newReleaseContentBlob, releaseContent, fileHasChanged }
+  })
+
  
   changesToHelmfile = await Promise.all(changesToHelmfile)
+  changesToLambdaFiles = await Promise.all(changesToLambdaFiles)
 
-  const filesHaveChanged = changesToHelmfile.some(({ fileHasChanged }) => fileHasChanged)
-  if (filesHaveChanged) {
-    await closePRs();
-    await createPR(projects, issueContent, changesToHelmfile);
+  const helmFilesHaveChanged = changesToHelmfile.some(({ fileHasChanged }) => fileHasChanged)
+  const lambdaFilesHaveChanged = changesToLambdaFiles.some(({ fileHasChanged }) => fileHasChanged)
+
+  if (helmFilesHaveChanged || lambdaFilesHaveChanged) {
+    // await closePRs();
+    await createPR(projects, projects_lambdas, issueContent, changesToHelmfile, changesToLambdaFiles);
   }
 }
 
 
 // Main execute ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-runHelmfile(PROJECTS);
+main(PROJECTS, PROJECTS_LAMBDAS);

--- a/index.js
+++ b/index.js
@@ -214,4 +214,4 @@ async function main(closePRsFirst, titlePrefix, projects, projects_lambdas) {
 
 // Main execute ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-main(true, "[TEST DO NOT MERGE]", PROJECTS, PROJECTS_LAMBDAS);
+main(true, "[AUTO-PR]", PROJECTS, PROJECTS_LAMBDAS);


### PR DESCRIPTION
# Summary | Résumé

api lambda image is no longer being updated ([example here](https://github.com/cds-snc/notification-manifests/pull/3483)).

In this PR I leave the helm related code alone and add specific "updating lambdas" code.

# Test instructions | Instructions pour tester la modification

I ran locally and generated [this PR](https://github.com/cds-snc/notification-manifests/pull/3485). Note that the file `.github/workflows/merge_to_main_production.yaml` now has the api lambda image tag changed.
