### PR TITLE
Release heartbeat changes again

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -56,7 +56,7 @@ async function createPR(
 ) {
   const branchName = `release-${new Date().getTime()}`;
   const manifestsSha = await getHeadSha("notification-manifests");
-  const logs = await buildLogs(projects);
+  const logs = await buildLogs([...projects, ...projects_lambdas]);
 
   const ref = await octokit.rest.git.createRef({
     owner: GH_CDS,
@@ -7114,12 +7114,12 @@ const PROJECTS_LAMBDAS = [
   //   ecrUrl: "${PRODUCTION_ECR_ACCOUNT}.dkr.ecr.ca-central-1.amazonaws.com/notify",
   //   ecrName: "system_status",
   // },
-  // {
-  //   repoName: "notification-lambdas",
-  //   manifestFile: ".github/workflows/merge_to_main_production.yaml",
-  //   ecrUrl: "${PRODUCTION_ECR_ACCOUNT}.dkr.ecr.ca-central-1.amazonaws.com/notify",
-  //   ecrName: "heartbeat",
-  // },
+  {
+    repoName: "notification-lambdas",
+    manifestFile: ".github/workflows/merge_to_main_production.yaml",
+    ecrUrl: "${PRODUCTION_ECR_ACCOUNT}.dkr.ecr.ca-central-1.amazonaws.com/notify",
+    ecrName: "heartbeat",
+  },
 ]
 
 // Shas ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/dist/index.js
+++ b/dist/index.js
@@ -56,7 +56,7 @@ async function createPR(
 ) {
   const branchName = `release-${new Date().getTime()}`;
   const manifestsSha = await getHeadSha("notification-manifests");
-  const logs = await buildLogs([...projects, ...projects_lambdas]);
+  const logs = await buildLogs(projects);
 
   const ref = await octokit.rest.git.createRef({
     owner: GH_CDS,

--- a/github.js
+++ b/github.js
@@ -50,7 +50,7 @@ async function createPR(
 ) {
   const branchName = `release-${new Date().getTime()}`;
   const manifestsSha = await getHeadSha("notification-manifests");
-  const logs = await buildLogs(projects);
+  const logs = await buildLogs([...projects, ...projects_lambdas]);
 
   const ref = await octokit.rest.git.createRef({
     owner: GH_CDS,

--- a/github.js
+++ b/github.js
@@ -50,7 +50,7 @@ async function createPR(
 ) {
   const branchName = `release-${new Date().getTime()}`;
   const manifestsSha = await getHeadSha("notification-manifests");
-  const logs = await buildLogs([...projects, ...projects_lambdas]);
+  const logs = await buildLogs(projects);
 
   const ref = await octokit.rest.git.createRef({
     owner: GH_CDS,

--- a/index.js
+++ b/index.js
@@ -48,12 +48,12 @@ const PROJECTS_LAMBDAS = [
   //   ecrUrl: "${PRODUCTION_ECR_ACCOUNT}.dkr.ecr.ca-central-1.amazonaws.com/notify",
   //   ecrName: "system_status",
   // },
-  // {
-  //   repoName: "notification-lambdas",
-  //   manifestFile: ".github/workflows/merge_to_main_production.yaml",
-  //   ecrUrl: "${PRODUCTION_ECR_ACCOUNT}.dkr.ecr.ca-central-1.amazonaws.com/notify",
-  //   ecrName: "heartbeat",
-  // },
+  {
+    repoName: "notification-lambdas",
+    manifestFile: ".github/workflows/merge_to_main_production.yaml",
+    ecrUrl: "${PRODUCTION_ECR_ACCOUNT}.dkr.ecr.ca-central-1.amazonaws.com/notify",
+    ecrName: "heartbeat",
+  },
 ]
 
 // Shas ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~


### PR DESCRIPTION
# Summary | Résumé

[Some yahoo took out the code to release the heartbeat](https://github.com/cds-snc/notification-pr-bot/pull/46), but we're uploading the docker image to prod ECR now so I guess the problem got fixed in the last year?

This PR adds the heartbeat back to the pr-bot release PRs 

# Test instructions | Instructions pour tester la modification

Ran manually to produce [this PR](https://github.com/cds-snc/notification-manifests/pull/3503). Note that the long list of PRs in the lambda section was because we haven't updated the heartbeat in a year. Should be shorter next time?
