### PR TITLE
Add lambda changes to the release PR

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -56,7 +56,9 @@ async function createPR(
 ) {
   const branchName = `release-${new Date().getTime()}`;
   const manifestsSha = await getHeadSha("notification-manifests");
-  const logs = await buildLogs(projects);
+  // pass in the projects and projects_lambdas so that the changes for all repos
+  // will be listed in the PR
+  const logs = await buildLogs([...projects, ...projects_lambdas]);
 
   const ref = await octokit.rest.git.createRef({
     owner: GH_CDS,
@@ -7198,9 +7200,6 @@ function shortSha(fullSha) {
         const originalFileContents = Base64.decode(releaseContent.content)
         const re = new RegExp(`${project.ecrName}:\\S*`, "g");
         matches = originalFileContents.match(re);
-        console.log(`re for ${project.ecrName}:`, re);
-        console.log(`Original file contents for ${project.ecrName}:`, originalFileContents);
-        console.log(`Matches for ${project.ecrName}:`, matches);
         project.oldUrl = matches[0]
         project.oldSha = getLambdaSha(project.oldUrl);
         return project;

--- a/github.js
+++ b/github.js
@@ -50,7 +50,9 @@ async function createPR(
 ) {
   const branchName = `release-${new Date().getTime()}`;
   const manifestsSha = await getHeadSha("notification-manifests");
-  const logs = await buildLogs(projects);
+  // pass in the projects and projects_lambdas so that the changes for all repos
+  // will be listed in the PR
+  const logs = await buildLogs([...projects, ...projects_lambdas]);
 
   const ref = await octokit.rest.git.createRef({
     owner: GH_CDS,

--- a/index.js
+++ b/index.js
@@ -132,9 +132,6 @@ function shortSha(fullSha) {
         const originalFileContents = Base64.decode(releaseContent.content)
         const re = new RegExp(`${project.ecrName}:\\S*`, "g");
         matches = originalFileContents.match(re);
-        console.log(`re for ${project.ecrName}:`, re);
-        console.log(`Original file contents for ${project.ecrName}:`, originalFileContents);
-        console.log(`Matches for ${project.ecrName}:`, matches);
         project.oldUrl = matches[0]
         project.oldSha = getLambdaSha(project.oldUrl);
         return project;


### PR DESCRIPTION
# Summary | Résumé

 This PR:
- removes debugging log statements that are no longer needed
- passes in the `projects` and `projects_lambdas` to the `buildLogs` fn so that the changes for all repos will be listed in the auto generated manifest release PR. It is okay to pass in multiple objects with the same repo because the `buildLogs` fn handles that and just gets one set of commits per unique repo: https://github.com/cds-snc/notification-pr-bot/blob/main/github.js#L121

# Test instructions | Instructions pour tester la modification

Future release PRs should include changes to the notification-lambdas repo.