### PR TITLE
Terraform Auto PR Template Adjustment

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -188,9 +188,6 @@ async function buildLogs(projects, extraFileChanges = []) {
       );
       const extraSummary = [
         `Releasing Terraform infrastructure from \`${tfChange.oldVersion}\` to \`${tfChange.latestVersion}\`.`,
-        "",
-        "NOTIFICATION-TERRAFORM",
-        "",
         commitLog,
       ].join("\n");
       logs = logs ? `${extraSummary}\n\n${logs}` : extraSummary;
@@ -294,16 +291,18 @@ async function getTerraformModuleCommitSummary(oldVersion, latestVersion) {
         const cleanMessage = message.replace(/\s*\(#\d+\)$/, "");
         if (prNumber) {
           const prUrl = `https://github.com/${GH_CDS}/notification-terraform/pull/${prNumber}`;
-          return `- [#${prNumber}](${prUrl}) ${cleanMessage} — ${authorName} [${moduleList}]`;
+          return `- [#${prNumber}](${prUrl}) - ${cleanMessage} — ${authorName} [${moduleList}]`;
         }
 
-        return `- [commit](${url}) ${cleanMessage} — ${authorName} [${moduleList}]`;
+        return `- [commit](${url}) - ${cleanMessage} — ${authorName} [${moduleList}]`;
       })
       .join("\n");
 
     const copyReadySection = [
       "<details>",
       "<summary>Copy Rendered Summary</summary>",
+      "",
+      "NOTIFICATION-TERRAFORM",
       "",
       copyReadyLines,
       "</details>",

--- a/dist/index.js
+++ b/dist/index.js
@@ -55,6 +55,10 @@ async function closePRs(titlePrefix) {
 const GENERATED_SUMMARY_PLACEHOLDER = "<!-- RELEASE_SUMMARY -->";
 
 function injectGeneratedContent(issueContent, logs) {
+  if (TARGET_REPO === "notification-terraform") {
+    return issueContent.replace(GENERATED_SUMMARY_PLACEHOLDER, logs);
+  }
+
   if (issueContent.includes(GENERATED_SUMMARY_PLACEHOLDER)) {
     return issueContent.replace(GENERATED_SUMMARY_PLACEHOLDER, logs);
   }

--- a/dist/index.js
+++ b/dist/index.js
@@ -55,10 +55,12 @@ async function closePRs(titlePrefix) {
 const GENERATED_SUMMARY_PLACEHOLDER = "<!-- RELEASE_SUMMARY -->";
 
 function injectGeneratedContent(issueContent, logs) {
-  if (TARGET_REPO === "notification-terraform") {
+  // Prefer the shared summary placeholder used by release templates.
+  if (issueContent.includes(GENERATED_SUMMARY_PLACEHOLDER)) {
     return issueContent.replace(GENERATED_SUMMARY_PLACEHOLDER, logs);
   }
 
+  // Backward compatibility for legacy templates that predate RELEASE_SUMMARY.
   return issueContent
     .replace(
       "> What is changing and why? (e.g. security patching, scaling API pods, new feature deployment)",
@@ -167,17 +169,73 @@ function uniqueByKey(items, key) {
   return [...new Map(items.map(item => [item[key], item])).values()];
 }
 
+function escapeTableCell(content) {
+  return String(content).replace(/\\/g, "\\\\").replace(/\|/g, "\\|");
+}
+
+function getCommitSummaryLine(commit, componentLabel) {
+  const prMatch = commit.message.match(/\(#(\d+)\)/);
+  const cleanMessage = commit.message.replace(/\s*\(#\d+\)$/, "");
+
+  if (prMatch) {
+    const prNumber = prMatch[1];
+    const prUrl = `https://github.com/${GH_CDS}/${commit.repoName}/pull/${prNumber}`;
+    return `- [#${prNumber}](${prUrl}) - ${cleanMessage} — ${commit.authorName} [${componentLabel}]`;
+  }
+
+  return `- [commit](${commit.url}) - ${cleanMessage} — ${commit.authorName} [${componentLabel}]`;
+}
+
+function getCommitTableLine(commit) {
+  const safeMessage = escapeTableCell(commit.message);
+  const safeAuthor = escapeTableCell(commit.authorName);
+  return `- [${safeMessage}](${commit.url}) by ${safeAuthor}`;
+}
+
 async function buildLogs(projects, extraFileChanges = []) {
   const uniqueByRepo = uniqueByKey(projects, "repoName");
-  let logs = uniqueByRepo.map(async (project) => {
-    const msgsCommits = await getCommitMessages(project.repoName, project.oldSha);
-    const strCommits = msgsCommits.join("\n");
-    const projectName = project.repoName.toUpperCase();
-    return `${projectName}\n\n${strCommits}`;
-  });
-  
-  logs = await Promise.all(logs);
-  logs = logs.join("\n\n");
+  let logs = "";
+
+  if (uniqueByRepo.length > 0) {
+    const repoCommitGroups = await Promise.all(
+      uniqueByRepo.map(async (project) => {
+        const commits = await getCommitMessages(project.repoName, project.oldSha);
+        return {
+          componentLabel: project.repoName.toUpperCase(),
+          commits,
+        };
+      })
+    );
+
+    const copyReadyLines = repoCommitGroups
+      .flatMap(({ componentLabel, commits }) =>
+        commits.map((commit) => getCommitSummaryLine(commit, componentLabel))
+      )
+      .join("\n");
+
+    const copyReadySection = [
+      "<details>",
+      "<summary>Copy Rendered Summary</summary>",
+      "",
+      "NOTIFICATION-MANIFESTS",
+      "",
+      copyReadyLines,
+      "</details>",
+    ].join("\n");
+
+    const tableHeader = "| Component | Changes |\n| --- | --- |";
+    const tableRows = repoCommitGroups
+      .sort((a, b) => a.componentLabel.localeCompare(b.componentLabel))
+      .map(({ componentLabel, commits }) => {
+        const commitLines = commits.length
+          ? commits.map(getCommitTableLine).join("<br>")
+          : "_No new commits_";
+        return `| ${componentLabel} | ${commitLines} |`;
+      })
+      .join("\n");
+
+    logs = `${copyReadySection}\n\n${tableHeader}\n${tableRows}`;
+  }
 
   if (extraFileChanges.length > 0) {
     const tfChange = extraFileChanges.find(c => c.oldVersion);
@@ -199,12 +257,20 @@ async function buildLogs(projects, extraFileChanges = []) {
     }
   }
 
+  if (!logs) {
+    return "_No component-level changes detected in this release._";
+  }
+
   return logs;
 }
 
 function getTerraformModuleFromPath(path) {
   const match = path.match(/^aws\/([^/]+)\//);
   return match ? match[1] : null;
+}
+
+function isTerraformReleaseCommitMessage(message) {
+  return /^release\s+\d+\.\d+\.\d+\s+\(#\d+\)$/i.test(message.trim());
 }
 
 async function getTerraformModuleCommitSummary(oldVersion, latestVersion) {
@@ -223,9 +289,14 @@ async function getTerraformModuleCommitSummary(oldVersion, latestVersion) {
 
   const moduleToCommits = new Map();
 
-  if (comparison.commits && comparison.commits.length > 0) {
+  const relevantCommits = (comparison.commits || []).filter((commit) => {
+    const message = commit.commit.message.split("\n\n")[0];
+    return !isTerraformReleaseCommitMessage(message);
+  });
+
+  if (relevantCommits.length > 0) {
     const commitEntries = await Promise.all(
-      comparison.commits.map(async (commit) => {
+      relevantCommits.map(async (commit) => {
         const { data: commitData } = await octokit.rest.repos.getCommit({
           owner: GH_CDS,
           repo: "notification-terraform",
@@ -347,11 +418,12 @@ const getCommitMessages = async (repo, sha) => {
 
   return commits
     .slice(0, index)
-    .map(
-      (c) =>
-        `- [${c.commit.message.split("\n\n")[0]}](${c.html_url}) by ${c.commit.author.name
-        }`
-    );
+    .map((c) => ({
+      repoName: repo,
+      message: c.commit.message.split("\n\n")[0],
+      url: c.html_url,
+      authorName: c.commit.author ? c.commit.author.name : "Unknown",
+    }));
 };
 
 async function getContents(repo, path) {
@@ -7257,7 +7329,7 @@ function getRepoDefaults(targetRepo, awsEcrUrl) {
   const defaultsByRepo = {
     "notification-manifests": {
       titlePrefix: "[AUTO-PR]",
-      prTemplatePath: ".github/PULL_REQUEST_TEMPLATE.md",
+      prTemplatePath: ".github/release_pr_template.md",
       projects: manifestsProjects,
       projectsLambdas: manifestsLambdas,
     },

--- a/dist/index.js
+++ b/dist/index.js
@@ -52,6 +52,51 @@ async function closePRs(titlePrefix) {
   }
 }
 
+function replaceSectionBody(template, heading, body) {
+  const lines = template.split("\n");
+  const headingIndex = lines.findIndex((line) => line.trim() === heading);
+
+  if (headingIndex === -1) {
+    return null;
+  }
+
+  let start = headingIndex + 1;
+  while (start < lines.length && lines[start].trim() === "") {
+    start += 1;
+  }
+
+  let end = start;
+  while (end < lines.length && !lines[end].startsWith("## ")) {
+    end += 1;
+  }
+
+  const before = lines.slice(0, headingIndex + 1).join("\n");
+  const after = lines.slice(end).join("\n").replace(/^\n+/, "");
+
+  return `${before}\n\n${body}${after ? `\n\n${after}` : ""}`;
+}
+
+function injectGeneratedContent(issueContent, logs) {
+  const bySection =
+    replaceSectionBody(issueContent, "## Summary", logs) ||
+    replaceSectionBody(issueContent, "## Provide some background on the changes", logs);
+
+  if (bySection) {
+    return bySection;
+  }
+
+  return issueContent
+    .replace(
+      "> What is changing and why? (e.g. security patching, scaling API pods, new feature deployment)",
+      logs
+    )
+    .replace(
+      "> Give details ex. Security patching, content update, more API pods etc",
+      logs
+    )
+    .replace("_TODO: 1-3 sentence description of the changed you're proposing._", logs);
+}
+
 async function createPR(
   titlePrefix,
   projects, projects_lambdas,
@@ -137,9 +182,7 @@ async function createPR(
     title: title,
     head: branchName,
     base: "main",
-    body: issueContent
-      .replace("> Give details ex. Security patching, content update, more API pods etc", logs)
-      .replace("_TODO: 1-3 sentence description of the changed you're proposing._", logs),
+    body: injectGeneratedContent(issueContent, logs),
     draft: true,
   });
   return Promise.all([ref, pr]);
@@ -169,7 +212,13 @@ async function buildLogs(projects, extraFileChanges = []) {
         tfChange.oldVersion,
         tfChange.latestVersion
       );
-      const extraSummary = `NOTIFICATION-TERRAFORM\n\n${commitLog}`;
+      const extraSummary = [
+        `Releasing Terraform infrastructure from \`${tfChange.oldVersion}\` to \`${tfChange.latestVersion}\`.`,
+        "",
+        "### Module changes",
+        "",
+        commitLog,
+      ].join("\n");
       logs = logs ? `${extraSummary}\n\n${logs}` : extraSummary;
     } else {
       const extraSummary = extraFileChanges
@@ -7195,7 +7244,7 @@ function getRepoDefaults(targetRepo, awsEcrUrl) {
     },
     "notification-terraform": {
       titlePrefix: "[AUTO-PR]",
-      prTemplatePath: "pull_request_template.md",
+      prTemplatePath: ".github/release_pr_template.md",
       projects: [],
       projectsLambdas: [],
     },

--- a/dist/index.js
+++ b/dist/index.js
@@ -248,37 +248,87 @@ async function getTerraformModuleCommitSummary(oldVersion, latestVersion) {
         const authorName = commit.commit.author ? commit.commit.author.name : "Unknown";
         const message = commit.commit.message.split("\n\n")[0];
         const safeMessage = message.replace(/\\/g, "\\\\").replace(/\|/g, "\\|");
-        const bullet = `- [${safeMessage}](${commit.html_url}) by ${authorName}`;
+        const tableBullet = `- [${safeMessage}](${commit.html_url}) by ${authorName}`;
 
-        return { modules, bullet };
+        return {
+          modules,
+          message,
+          url: commit.html_url,
+          authorName,
+          tableBullet,
+        };
       })
     );
 
-    for (const { modules, bullet } of commitEntries) {
+    for (const { modules, tableBullet } of commitEntries) {
       for (const moduleName of modules) {
         const existing = moduleToCommits.get(moduleName) || [];
-        existing.push(bullet);
+        existing.push(tableBullet);
         moduleToCommits.set(moduleName, existing);
       }
     }
+
+    const commitToModules = new Map();
+    for (const { modules, message, url, authorName } of commitEntries) {
+      const key = `${url}|${message}`;
+      const existing = commitToModules.get(key) || {
+        message,
+        url,
+        authorName,
+        modules: new Set(),
+      };
+
+      for (const moduleName of modules) {
+        const moduleLabel = moduleName === "other" ? "Other" : moduleName;
+        existing.modules.add(moduleLabel);
+      }
+
+      commitToModules.set(key, existing);
+    }
+
+    const copyReadyLines = [...commitToModules.values()]
+      .map(({ message, url, authorName, modules }) => {
+        const moduleList = [...modules].sort().join(", ");
+        const prMatch = message.match(/\(#(\d+)\)/);
+        const prNumber = prMatch ? prMatch[1] : null;
+        const cleanMessage = message.replace(/\s*\(#\d+\)$/, "");
+        if (prNumber) {
+          const prUrl = `https://github.com/${GH_CDS}/notification-terraform/pull/${prNumber}`;
+          return `- [#${prNumber}](${prUrl}) ${cleanMessage} — ${authorName} [${moduleList}]`;
+        }
+
+        return `- [commit](${url}) ${cleanMessage} — ${authorName} [${moduleList}]`;
+      })
+      .join("\n");
+
+    const copyReadySection = [
+      "<details>",
+      "<summary>Copy Rendered Summary</summary>",
+      "",
+      copyReadyLines,
+      "</details>",
+    ].join("\n");
+
+    const sortedModules = [...moduleToCommits.keys()].sort();
+
+    if (sortedModules.length === 0) {
+      return "_No module-level changes detected in this release._";
+    }
+
+    const header = "| Module | Changes |\n| --- | --- |";
+    const rows = sortedModules
+      .map((moduleName) => {
+        const moduleLabel = moduleName === "other" ? "Other" : moduleName;
+        const commits = moduleToCommits.get(moduleName).join("<br>");
+        return `| ${moduleLabel} | ${commits} |`;
+      })
+      .join("\n");
+
+    const tableSection = `${header}\n${rows}`;
+    return `${copyReadySection}\n\n${tableSection}`;
   }
 
-  const sortedModules = [...moduleToCommits.keys()].sort();
-
-  if (sortedModules.length === 0) {
-    return "_No module-level changes detected in this release._";
-  }
-
-  const header = "| Module | Changes |\n| --- | --- |";
-  const rows = sortedModules
-    .map((moduleName) => {
-      const moduleLabel = moduleName === "other" ? "Other" : moduleName;
-      const commits = moduleToCommits.get(moduleName).join("<br>");
-      return `| ${moduleLabel} | ${commits} |`;
-    })
-    .join("\n");
-
-  return `${header}\n${rows}`;
+  return "_No module-level changes detected in this release._";
 }
 
 const getCommitMessages = async (repo, sha) => {

--- a/dist/index.js
+++ b/dist/index.js
@@ -52,37 +52,11 @@ async function closePRs(titlePrefix) {
   }
 }
 
-function replaceSectionBody(template, heading, body) {
-  const lines = template.split("\n");
-  const headingIndex = lines.findIndex((line) => line.trim() === heading);
-
-  if (headingIndex === -1) {
-    return null;
-  }
-
-  let start = headingIndex + 1;
-  while (start < lines.length && lines[start].trim() === "") {
-    start += 1;
-  }
-
-  let end = start;
-  while (end < lines.length && !lines[end].startsWith("## ")) {
-    end += 1;
-  }
-
-  const before = lines.slice(0, headingIndex + 1).join("\n");
-  const after = lines.slice(end).join("\n").replace(/^\n+/, "");
-
-  return `${before}\n\n${body}${after ? `\n\n${after}` : ""}`;
-}
+const GENERATED_SUMMARY_PLACEHOLDER = "<!-- RELEASE_SUMMARY -->";
 
 function injectGeneratedContent(issueContent, logs) {
-  const bySection =
-    replaceSectionBody(issueContent, "## Summary", logs) ||
-    replaceSectionBody(issueContent, "## Provide some background on the changes", logs);
-
-  if (bySection) {
-    return bySection;
+  if (issueContent.includes(GENERATED_SUMMARY_PLACEHOLDER)) {
+    return issueContent.replace(GENERATED_SUMMARY_PLACEHOLDER, logs);
   }
 
   return issueContent
@@ -398,21 +372,6 @@ const getLatestTag = async (repo) => {
   // Return the first valid tag (GitHub API returns them in reverse chronological order)
   return versionTags[0].name;
 };
-async function isNotLatestManifestsVersion() {
-  const releaseConfig = await getContents(
-    "notification-manifests",
-    "VERSION"
-  );
-
-  const prodVersion = Base64.decode(releaseConfig.content);
-  const latestVersion = await getLatestTag("notification-manifests");
-  return prodVersion != latestVersion;
-}
-
-async function isNotLatestTerraformVersion() {
-  const terraformVersionChange = await getTerraformVersionChange();
-  return terraformVersionChange && terraformVersionChange.fileHasChanged;
-}
 
 async function getTerraformVersionChange(force = false) {
   const prodWorkflow = await getContents(

--- a/dist/index.js
+++ b/dist/index.js
@@ -211,7 +211,6 @@ function getTerraformModuleFromPath(path) {
 }
 
 async function getTerraformModuleCommitSummary(oldVersion, latestVersion) {
-  const allModules = await getTerraformModules();
   const oldTagRef = await getTagRef("notification-terraform", oldVersion);
   const latestTagRef = await getTagRef("notification-terraform", latestVersion);
 
@@ -264,30 +263,22 @@ async function getTerraformModuleCommitSummary(oldVersion, latestVersion) {
     }
   }
 
-  const sortedModules = [...new Set([...allModules, ...moduleToCommits.keys()])].sort();
+  const sortedModules = [...moduleToCommits.keys()].sort();
+
+  if (sortedModules.length === 0) {
+    return "_No module-level changes detected in this release._";
+  }
+
   const header = "| Module | Changes |\n| --- | --- |";
   const rows = sortedModules
     .map((moduleName) => {
       const moduleLabel = moduleName === "other" ? "Other" : moduleName;
-      const commits = moduleToCommits.has(moduleName)
-        ? moduleToCommits.get(moduleName).join("<br>")
-        : "_No changes in this release._";
+      const commits = moduleToCommits.get(moduleName).join("<br>");
       return `| ${moduleLabel} | ${commits} |`;
     })
     .join("\n");
 
   return `${header}\n${rows}`;
-}
-
-async function getTerraformModules() {
-  const awsContents = await getContents("notification-terraform", "aws");
-  if (!Array.isArray(awsContents)) {
-    return [];
-  }
-
-  return awsContents
-    .filter((item) => item.type === "dir")
-    .map((item) => item.name);
 }
 
 const getCommitMessages = async (repo, sha) => {

--- a/dist/index.js
+++ b/dist/index.js
@@ -59,10 +59,6 @@ function injectGeneratedContent(issueContent, logs) {
     return issueContent.replace(GENERATED_SUMMARY_PLACEHOLDER, logs);
   }
 
-  if (issueContent.includes(GENERATED_SUMMARY_PLACEHOLDER)) {
-    return issueContent.replace(GENERATED_SUMMARY_PLACEHOLDER, logs);
-  }
-
   return issueContent
     .replace(
       "> What is changing and why? (e.g. security patching, scaling API pods, new feature deployment)",
@@ -193,7 +189,7 @@ async function buildLogs(projects, extraFileChanges = []) {
       const extraSummary = [
         `Releasing Terraform infrastructure from \`${tfChange.oldVersion}\` to \`${tfChange.latestVersion}\`.`,
         "",
-        "### Module changes",
+        "NOTIFICATION-TERRAFORM",
         "",
         commitLog,
       ].join("\n");
@@ -377,6 +373,22 @@ const getLatestTag = async (repo) => {
   return versionTags[0].name;
 };
 
+async function isNotLatestManifestsVersion() {
+  const releaseConfig = await getContents(
+    "notification-manifests",
+    "VERSION"
+  );
+
+  const prodVersion = Base64.decode(releaseConfig.content);
+  const latestVersion = await getLatestTag("notification-manifests");
+  return prodVersion != latestVersion;
+}
+
+async function isNotLatestTerraformVersion() {
+  const terraformVersionChange = await getTerraformVersionChange();
+  return terraformVersionChange && terraformVersionChange.fileHasChanged;
+}
+
 async function getTerraformVersionChange(force = false) {
   const prodWorkflow = await getContents(
     "notification-terraform",
@@ -410,10 +422,14 @@ module.exports = {
   GH_CDS,
   AWS_ECR_URL,
   TARGET_REPO,
+  buildLogs,
   closePRs,
   createPR,
   getContents,
   getHeadSha,
+  injectGeneratedContent,
+  isNotLatestManifestsVersion,
+  isNotLatestTerraformVersion,
   getTerraformVersionChange,
 }
 

--- a/github.js
+++ b/github.js
@@ -53,10 +53,6 @@ function injectGeneratedContent(issueContent, logs) {
     return issueContent.replace(GENERATED_SUMMARY_PLACEHOLDER, logs);
   }
 
-  if (issueContent.includes(GENERATED_SUMMARY_PLACEHOLDER)) {
-    return issueContent.replace(GENERATED_SUMMARY_PLACEHOLDER, logs);
-  }
-
   return issueContent
     .replace(
       "> What is changing and why? (e.g. security patching, scaling API pods, new feature deployment)",
@@ -187,7 +183,7 @@ async function buildLogs(projects, extraFileChanges = []) {
       const extraSummary = [
         `Releasing Terraform infrastructure from \`${tfChange.oldVersion}\` to \`${tfChange.latestVersion}\`.`,
         "",
-        "### Module changes",
+        "NOTIFICATION-TERRAFORM",
         "",
         commitLog,
       ].join("\n");
@@ -371,6 +367,22 @@ const getLatestTag = async (repo) => {
   return versionTags[0].name;
 };
 
+async function isNotLatestManifestsVersion() {
+  const releaseConfig = await getContents(
+    "notification-manifests",
+    "VERSION"
+  );
+
+  const prodVersion = Base64.decode(releaseConfig.content);
+  const latestVersion = await getLatestTag("notification-manifests");
+  return prodVersion != latestVersion;
+}
+
+async function isNotLatestTerraformVersion() {
+  const terraformVersionChange = await getTerraformVersionChange();
+  return terraformVersionChange && terraformVersionChange.fileHasChanged;
+}
+
 async function getTerraformVersionChange(force = false) {
   const prodWorkflow = await getContents(
     "notification-terraform",
@@ -404,9 +416,13 @@ module.exports = {
   GH_CDS,
   AWS_ECR_URL,
   TARGET_REPO,
+  buildLogs,
   closePRs,
   createPR,
   getContents,
   getHeadSha,
+  injectGeneratedContent,
+  isNotLatestManifestsVersion,
+  isNotLatestTerraformVersion,
   getTerraformVersionChange,
 }

--- a/github.js
+++ b/github.js
@@ -182,9 +182,6 @@ async function buildLogs(projects, extraFileChanges = []) {
       );
       const extraSummary = [
         `Releasing Terraform infrastructure from \`${tfChange.oldVersion}\` to \`${tfChange.latestVersion}\`.`,
-        "",
-        "NOTIFICATION-TERRAFORM",
-        "",
         commitLog,
       ].join("\n");
       logs = logs ? `${extraSummary}\n\n${logs}` : extraSummary;
@@ -288,16 +285,18 @@ async function getTerraformModuleCommitSummary(oldVersion, latestVersion) {
         const cleanMessage = message.replace(/\s*\(#\d+\)$/, "");
         if (prNumber) {
           const prUrl = `https://github.com/${GH_CDS}/notification-terraform/pull/${prNumber}`;
-          return `- [#${prNumber}](${prUrl}) ${cleanMessage} — ${authorName} [${moduleList}]`;
+          return `- [#${prNumber}](${prUrl}) - ${cleanMessage} — ${authorName} [${moduleList}]`;
         }
 
-        return `- [commit](${url}) ${cleanMessage} — ${authorName} [${moduleList}]`;
+        return `- [commit](${url}) - ${cleanMessage} — ${authorName} [${moduleList}]`;
       })
       .join("\n");
 
     const copyReadySection = [
       "<details>",
       "<summary>Copy Rendered Summary</summary>",
+      "",
+      "NOTIFICATION-TERRAFORM",
       "",
       copyReadyLines,
       "</details>",

--- a/github.js
+++ b/github.js
@@ -46,37 +46,11 @@ async function closePRs(titlePrefix) {
   }
 }
 
-function replaceSectionBody(template, heading, body) {
-  const lines = template.split("\n");
-  const headingIndex = lines.findIndex((line) => line.trim() === heading);
-
-  if (headingIndex === -1) {
-    return null;
-  }
-
-  let start = headingIndex + 1;
-  while (start < lines.length && lines[start].trim() === "") {
-    start += 1;
-  }
-
-  let end = start;
-  while (end < lines.length && !lines[end].startsWith("## ")) {
-    end += 1;
-  }
-
-  const before = lines.slice(0, headingIndex + 1).join("\n");
-  const after = lines.slice(end).join("\n").replace(/^\n+/, "");
-
-  return `${before}\n\n${body}${after ? `\n\n${after}` : ""}`;
-}
+const GENERATED_SUMMARY_PLACEHOLDER = "<!-- RELEASE_SUMMARY -->";
 
 function injectGeneratedContent(issueContent, logs) {
-  const bySection =
-    replaceSectionBody(issueContent, "## Summary", logs) ||
-    replaceSectionBody(issueContent, "## Provide some background on the changes", logs);
-
-  if (bySection) {
-    return bySection;
+  if (issueContent.includes(GENERATED_SUMMARY_PLACEHOLDER)) {
+    return issueContent.replace(GENERATED_SUMMARY_PLACEHOLDER, logs);
   }
 
   return issueContent
@@ -392,21 +366,6 @@ const getLatestTag = async (repo) => {
   // Return the first valid tag (GitHub API returns them in reverse chronological order)
   return versionTags[0].name;
 };
-async function isNotLatestManifestsVersion() {
-  const releaseConfig = await getContents(
-    "notification-manifests",
-    "VERSION"
-  );
-
-  const prodVersion = Base64.decode(releaseConfig.content);
-  const latestVersion = await getLatestTag("notification-manifests");
-  return prodVersion != latestVersion;
-}
-
-async function isNotLatestTerraformVersion() {
-  const terraformVersionChange = await getTerraformVersionChange();
-  return terraformVersionChange && terraformVersionChange.fileHasChanged;
-}
 
 async function getTerraformVersionChange(force = false) {
   const prodWorkflow = await getContents(

--- a/github.js
+++ b/github.js
@@ -49,6 +49,10 @@ async function closePRs(titlePrefix) {
 const GENERATED_SUMMARY_PLACEHOLDER = "<!-- RELEASE_SUMMARY -->";
 
 function injectGeneratedContent(issueContent, logs) {
+  if (TARGET_REPO === "notification-terraform") {
+    return issueContent.replace(GENERATED_SUMMARY_PLACEHOLDER, logs);
+  }
+
   if (issueContent.includes(GENERATED_SUMMARY_PLACEHOLDER)) {
     return issueContent.replace(GENERATED_SUMMARY_PLACEHOLDER, logs);
   }

--- a/github.js
+++ b/github.js
@@ -46,6 +46,51 @@ async function closePRs(titlePrefix) {
   }
 }
 
+function replaceSectionBody(template, heading, body) {
+  const lines = template.split("\n");
+  const headingIndex = lines.findIndex((line) => line.trim() === heading);
+
+  if (headingIndex === -1) {
+    return null;
+  }
+
+  let start = headingIndex + 1;
+  while (start < lines.length && lines[start].trim() === "") {
+    start += 1;
+  }
+
+  let end = start;
+  while (end < lines.length && !lines[end].startsWith("## ")) {
+    end += 1;
+  }
+
+  const before = lines.slice(0, headingIndex + 1).join("\n");
+  const after = lines.slice(end).join("\n").replace(/^\n+/, "");
+
+  return `${before}\n\n${body}${after ? `\n\n${after}` : ""}`;
+}
+
+function injectGeneratedContent(issueContent, logs) {
+  const bySection =
+    replaceSectionBody(issueContent, "## Summary", logs) ||
+    replaceSectionBody(issueContent, "## Provide some background on the changes", logs);
+
+  if (bySection) {
+    return bySection;
+  }
+
+  return issueContent
+    .replace(
+      "> What is changing and why? (e.g. security patching, scaling API pods, new feature deployment)",
+      logs
+    )
+    .replace(
+      "> Give details ex. Security patching, content update, more API pods etc",
+      logs
+    )
+    .replace("_TODO: 1-3 sentence description of the changed you're proposing._", logs);
+}
+
 async function createPR(
   titlePrefix,
   projects, projects_lambdas,
@@ -131,9 +176,7 @@ async function createPR(
     title: title,
     head: branchName,
     base: "main",
-    body: issueContent
-      .replace("> Give details ex. Security patching, content update, more API pods etc", logs)
-      .replace("_TODO: 1-3 sentence description of the changed you're proposing._", logs),
+    body: injectGeneratedContent(issueContent, logs),
     draft: true,
   });
   return Promise.all([ref, pr]);
@@ -163,7 +206,13 @@ async function buildLogs(projects, extraFileChanges = []) {
         tfChange.oldVersion,
         tfChange.latestVersion
       );
-      const extraSummary = `NOTIFICATION-TERRAFORM\n\n${commitLog}`;
+      const extraSummary = [
+        `Releasing Terraform infrastructure from \`${tfChange.oldVersion}\` to \`${tfChange.latestVersion}\`.`,
+        "",
+        "### Module changes",
+        "",
+        commitLog,
+      ].join("\n");
       logs = logs ? `${extraSummary}\n\n${logs}` : extraSummary;
     } else {
       const extraSummary = extraFileChanges

--- a/github.js
+++ b/github.js
@@ -242,37 +242,87 @@ async function getTerraformModuleCommitSummary(oldVersion, latestVersion) {
         const authorName = commit.commit.author ? commit.commit.author.name : "Unknown";
         const message = commit.commit.message.split("\n\n")[0];
         const safeMessage = message.replace(/\\/g, "\\\\").replace(/\|/g, "\\|");
-        const bullet = `- [${safeMessage}](${commit.html_url}) by ${authorName}`;
+        const tableBullet = `- [${safeMessage}](${commit.html_url}) by ${authorName}`;
 
-        return { modules, bullet };
+        return {
+          modules,
+          message,
+          url: commit.html_url,
+          authorName,
+          tableBullet,
+        };
       })
     );
 
-    for (const { modules, bullet } of commitEntries) {
+    for (const { modules, tableBullet } of commitEntries) {
       for (const moduleName of modules) {
         const existing = moduleToCommits.get(moduleName) || [];
-        existing.push(bullet);
+        existing.push(tableBullet);
         moduleToCommits.set(moduleName, existing);
       }
     }
+
+    const commitToModules = new Map();
+    for (const { modules, message, url, authorName } of commitEntries) {
+      const key = `${url}|${message}`;
+      const existing = commitToModules.get(key) || {
+        message,
+        url,
+        authorName,
+        modules: new Set(),
+      };
+
+      for (const moduleName of modules) {
+        const moduleLabel = moduleName === "other" ? "Other" : moduleName;
+        existing.modules.add(moduleLabel);
+      }
+
+      commitToModules.set(key, existing);
+    }
+
+    const copyReadyLines = [...commitToModules.values()]
+      .map(({ message, url, authorName, modules }) => {
+        const moduleList = [...modules].sort().join(", ");
+        const prMatch = message.match(/\(#(\d+)\)/);
+        const prNumber = prMatch ? prMatch[1] : null;
+        const cleanMessage = message.replace(/\s*\(#\d+\)$/, "");
+        if (prNumber) {
+          const prUrl = `https://github.com/${GH_CDS}/notification-terraform/pull/${prNumber}`;
+          return `- [#${prNumber}](${prUrl}) ${cleanMessage} — ${authorName} [${moduleList}]`;
+        }
+
+        return `- [commit](${url}) ${cleanMessage} — ${authorName} [${moduleList}]`;
+      })
+      .join("\n");
+
+    const copyReadySection = [
+      "<details>",
+      "<summary>Copy Rendered Summary</summary>",
+      "",
+      copyReadyLines,
+      "</details>",
+    ].join("\n");
+
+    const sortedModules = [...moduleToCommits.keys()].sort();
+
+    if (sortedModules.length === 0) {
+      return "_No module-level changes detected in this release._";
+    }
+
+    const header = "| Module | Changes |\n| --- | --- |";
+    const rows = sortedModules
+      .map((moduleName) => {
+        const moduleLabel = moduleName === "other" ? "Other" : moduleName;
+        const commits = moduleToCommits.get(moduleName).join("<br>");
+        return `| ${moduleLabel} | ${commits} |`;
+      })
+      .join("\n");
+
+    const tableSection = `${header}\n${rows}`;
+    return `${copyReadySection}\n\n${tableSection}`;
   }
 
-  const sortedModules = [...moduleToCommits.keys()].sort();
-
-  if (sortedModules.length === 0) {
-    return "_No module-level changes detected in this release._";
-  }
-
-  const header = "| Module | Changes |\n| --- | --- |";
-  const rows = sortedModules
-    .map((moduleName) => {
-      const moduleLabel = moduleName === "other" ? "Other" : moduleName;
-      const commits = moduleToCommits.get(moduleName).join("<br>");
-      return `| ${moduleLabel} | ${commits} |`;
-    })
-    .join("\n");
-
-  return `${header}\n${rows}`;
+  return "_No module-level changes detected in this release._";
 }
 
 const getCommitMessages = async (repo, sha) => {

--- a/github.js
+++ b/github.js
@@ -205,7 +205,6 @@ function getTerraformModuleFromPath(path) {
 }
 
 async function getTerraformModuleCommitSummary(oldVersion, latestVersion) {
-  const allModules = await getTerraformModules();
   const oldTagRef = await getTagRef("notification-terraform", oldVersion);
   const latestTagRef = await getTagRef("notification-terraform", latestVersion);
 
@@ -258,30 +257,22 @@ async function getTerraformModuleCommitSummary(oldVersion, latestVersion) {
     }
   }
 
-  const sortedModules = [...new Set([...allModules, ...moduleToCommits.keys()])].sort();
+  const sortedModules = [...moduleToCommits.keys()].sort();
+
+  if (sortedModules.length === 0) {
+    return "_No module-level changes detected in this release._";
+  }
+
   const header = "| Module | Changes |\n| --- | --- |";
   const rows = sortedModules
     .map((moduleName) => {
       const moduleLabel = moduleName === "other" ? "Other" : moduleName;
-      const commits = moduleToCommits.has(moduleName)
-        ? moduleToCommits.get(moduleName).join("<br>")
-        : "_No changes in this release._";
+      const commits = moduleToCommits.get(moduleName).join("<br>");
       return `| ${moduleLabel} | ${commits} |`;
     })
     .join("\n");
 
   return `${header}\n${rows}`;
-}
-
-async function getTerraformModules() {
-  const awsContents = await getContents("notification-terraform", "aws");
-  if (!Array.isArray(awsContents)) {
-    return [];
-  }
-
-  return awsContents
-    .filter((item) => item.type === "dir")
-    .map((item) => item.name);
 }
 
 const getCommitMessages = async (repo, sha) => {

--- a/github.js
+++ b/github.js
@@ -49,10 +49,12 @@ async function closePRs(titlePrefix) {
 const GENERATED_SUMMARY_PLACEHOLDER = "<!-- RELEASE_SUMMARY -->";
 
 function injectGeneratedContent(issueContent, logs) {
-  if (TARGET_REPO === "notification-terraform") {
+  // Prefer the shared summary placeholder used by release templates.
+  if (issueContent.includes(GENERATED_SUMMARY_PLACEHOLDER)) {
     return issueContent.replace(GENERATED_SUMMARY_PLACEHOLDER, logs);
   }
 
+  // Backward compatibility for legacy templates that predate RELEASE_SUMMARY.
   return issueContent
     .replace(
       "> What is changing and why? (e.g. security patching, scaling API pods, new feature deployment)",
@@ -161,17 +163,73 @@ function uniqueByKey(items, key) {
   return [...new Map(items.map(item => [item[key], item])).values()];
 }
 
+function escapeTableCell(content) {
+  return String(content).replace(/\\/g, "\\\\").replace(/\|/g, "\\|");
+}
+
+function getCommitSummaryLine(commit, componentLabel) {
+  const prMatch = commit.message.match(/\(#(\d+)\)/);
+  const cleanMessage = commit.message.replace(/\s*\(#\d+\)$/, "");
+
+  if (prMatch) {
+    const prNumber = prMatch[1];
+    const prUrl = `https://github.com/${GH_CDS}/${commit.repoName}/pull/${prNumber}`;
+    return `- [#${prNumber}](${prUrl}) - ${cleanMessage} — ${commit.authorName} [${componentLabel}]`;
+  }
+
+  return `- [commit](${commit.url}) - ${cleanMessage} — ${commit.authorName} [${componentLabel}]`;
+}
+
+function getCommitTableLine(commit) {
+  const safeMessage = escapeTableCell(commit.message);
+  const safeAuthor = escapeTableCell(commit.authorName);
+  return `- [${safeMessage}](${commit.url}) by ${safeAuthor}`;
+}
+
 async function buildLogs(projects, extraFileChanges = []) {
   const uniqueByRepo = uniqueByKey(projects, "repoName");
-  let logs = uniqueByRepo.map(async (project) => {
-    const msgsCommits = await getCommitMessages(project.repoName, project.oldSha);
-    const strCommits = msgsCommits.join("\n");
-    const projectName = project.repoName.toUpperCase();
-    return `${projectName}\n\n${strCommits}`;
-  });
-  
-  logs = await Promise.all(logs);
-  logs = logs.join("\n\n");
+  let logs = "";
+
+  if (uniqueByRepo.length > 0) {
+    const repoCommitGroups = await Promise.all(
+      uniqueByRepo.map(async (project) => {
+        const commits = await getCommitMessages(project.repoName, project.oldSha);
+        return {
+          componentLabel: project.repoName.toUpperCase(),
+          commits,
+        };
+      })
+    );
+
+    const copyReadyLines = repoCommitGroups
+      .flatMap(({ componentLabel, commits }) =>
+        commits.map((commit) => getCommitSummaryLine(commit, componentLabel))
+      )
+      .join("\n");
+
+    const copyReadySection = [
+      "<details>",
+      "<summary>Copy Rendered Summary</summary>",
+      "",
+      "NOTIFICATION-MANIFESTS",
+      "",
+      copyReadyLines,
+      "</details>",
+    ].join("\n");
+
+    const tableHeader = "| Component | Changes |\n| --- | --- |";
+    const tableRows = repoCommitGroups
+      .sort((a, b) => a.componentLabel.localeCompare(b.componentLabel))
+      .map(({ componentLabel, commits }) => {
+        const commitLines = commits.length
+          ? commits.map(getCommitTableLine).join("<br>")
+          : "_No new commits_";
+        return `| ${componentLabel} | ${commitLines} |`;
+      })
+      .join("\n");
+
+    logs = `${copyReadySection}\n\n${tableHeader}\n${tableRows}`;
+  }
 
   if (extraFileChanges.length > 0) {
     const tfChange = extraFileChanges.find(c => c.oldVersion);
@@ -193,12 +251,20 @@ async function buildLogs(projects, extraFileChanges = []) {
     }
   }
 
+  if (!logs) {
+    return "_No component-level changes detected in this release._";
+  }
+
   return logs;
 }
 
 function getTerraformModuleFromPath(path) {
   const match = path.match(/^aws\/([^/]+)\//);
   return match ? match[1] : null;
+}
+
+function isTerraformReleaseCommitMessage(message) {
+  return /^release\s+\d+\.\d+\.\d+\s+\(#\d+\)$/i.test(message.trim());
 }
 
 async function getTerraformModuleCommitSummary(oldVersion, latestVersion) {
@@ -217,9 +283,14 @@ async function getTerraformModuleCommitSummary(oldVersion, latestVersion) {
 
   const moduleToCommits = new Map();
 
-  if (comparison.commits && comparison.commits.length > 0) {
+  const relevantCommits = (comparison.commits || []).filter((commit) => {
+    const message = commit.commit.message.split("\n\n")[0];
+    return !isTerraformReleaseCommitMessage(message);
+  });
+
+  if (relevantCommits.length > 0) {
     const commitEntries = await Promise.all(
-      comparison.commits.map(async (commit) => {
+      relevantCommits.map(async (commit) => {
         const { data: commitData } = await octokit.rest.repos.getCommit({
           owner: GH_CDS,
           repo: "notification-terraform",
@@ -341,11 +412,12 @@ const getCommitMessages = async (repo, sha) => {
 
   return commits
     .slice(0, index)
-    .map(
-      (c) =>
-        `- [${c.commit.message.split("\n\n")[0]}](${c.html_url}) by ${c.commit.author.name
-        }`
-    );
+    .map((c) => ({
+      repoName: repo,
+      message: c.commit.message.split("\n\n")[0],
+      url: c.html_url,
+      authorName: c.commit.author ? c.commit.author.name : "Unknown",
+    }));
 };
 
 async function getContents(repo, path) {

--- a/repo-defaults.js
+++ b/repo-defaults.js
@@ -60,7 +60,7 @@ function getRepoDefaults(targetRepo, awsEcrUrl) {
   const defaultsByRepo = {
     "notification-manifests": {
       titlePrefix: "[AUTO-PR]",
-      prTemplatePath: ".github/PULL_REQUEST_TEMPLATE.md",
+      prTemplatePath: ".github/release_pr_template.md",
       projects: manifestsProjects,
       projectsLambdas: manifestsLambdas,
     },

--- a/repo-defaults.js
+++ b/repo-defaults.js
@@ -66,7 +66,7 @@ function getRepoDefaults(targetRepo, awsEcrUrl) {
     },
     "notification-terraform": {
       titlePrefix: "[AUTO-PR]",
-      prTemplatePath: "pull_request_template.md",
+      prTemplatePath: ".github/release_pr_template.md",
       projects: [],
       projectsLambdas: [],
     },


### PR DESCRIPTION
This pull request refactors how generated release summaries are injected into pull request bodies, improves the clarity of Terraform infrastructure release notes, and updates the template path for PRs in the `notification-terraform` repository. It also removes unused helper functions related to version checks.

**Release summary injection and template improvements:**

* Added a new `injectGeneratedContent` function in `github.js` to intelligently insert generated release logs into the PR body, supporting both placeholder-based and fallback replacements for different PR templates. This centralizes and simplifies content injection logic. [[1]](diffhunk://#diff-35d8b42b726adaa751252eb3ad98a7708f7be5ecf10ea6e637a42988b54d5a76R49-R71) [[2]](diffhunk://#diff-35d8b42b726adaa751252eb3ad98a7708f7be5ecf10ea6e637a42988b54d5a76L134-R157)
* Updated the PR template path for the `notification-terraform` repo in `repo-defaults.js` to `.github/release_pr_template.md`, ensuring the correct template is used for auto-generated PRs.

**Release summary formatting:**

* Improved the summary for Terraform infrastructure releases in `github.js` by making the description more explicit and structured, including version information and a dedicated "Module changes" section.

**Code cleanup:**

* Removed unused helper functions `isNotLatestManifestsVersion` and `isNotLatestTerraformVersion` from `github.js` to reduce dead code and potential confusion.