### PR TITLE
Suppressing TF infra version change in auto PR for TF

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -270,7 +270,9 @@ function getTerraformModuleFromPath(path) {
 }
 
 function isTerraformReleaseCommitMessage(message) {
-  return /^release\s+\d+\.\d+\.\d+\s+\(#\d+\)$/i.test(message.trim());
+  const isRelease = /^release\s+\d+\.\d+\.\d+\s+\(#\d+\)$/i.test(message.trim());
+  const isUpdateTracker = /^Update infrastructure version to\s+\d+\.\d+\.\d+.*$/i.test(message.trim());
+  return isRelease || isUpdateTracker;
 }
 
 async function getTerraformModuleCommitSummary(oldVersion, latestVersion) {

--- a/github.js
+++ b/github.js
@@ -264,7 +264,9 @@ function getTerraformModuleFromPath(path) {
 }
 
 function isTerraformReleaseCommitMessage(message) {
-  return /^release\s+\d+\.\d+\.\d+\s+\(#\d+\)$/i.test(message.trim());
+  const isRelease = /^release\s+\d+\.\d+\.\d+\s+\(#\d+\)$/i.test(message.trim());
+  const isUpdateTracker = /^Update infrastructure version to\s+\d+\.\d+\.\d+.*$/i.test(message.trim());
+  return isRelease || isUpdateTracker;
 }
 
 async function getTerraformModuleCommitSummary(oldVersion, latestVersion) {


### PR DESCRIPTION
# Summary | Résumé
This pull request updates the logic for identifying Terraform release commit messages to also recognize commit messages that indicate an update to the infrastructure version. This ensures that both standard release messages and version update messages are correctly detected.

Commit message detection improvements:

* Broadened the `isTerraformReleaseCommitMessage` function in `github.js` to also match commit messages starting with "Update infrastructure version to", in addition to the existing release message pattern.