### PR TITLE
removing lambda api dependencies

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -75,17 +75,15 @@ function injectGeneratedContent(issueContent, logs) {
 
 async function createPR(
   titlePrefix,
-  projects, projects_lambdas,
+  projects,
   issueContent,
-  changesToHelmfile, changesToLambdaFiles,
+  changesToHelmfile,
   extraFileChanges,
-
 ) {
   const branchName = `release-${new Date().getTime()}`;
   const targetRepoSha = await getHeadSha(TARGET_REPO);
-  // pass in the projects and projects_lambdas so that the changes for all repos
-  // will be listed in the PR
-  const logs = await buildLogs([...projects, ...projects_lambdas], extraFileChanges);
+  // pass in the projects so that the changes for all repos will be listed in the PR
+  const logs = await buildLogs(projects, extraFileChanges);
 
   const ref = await octokit.rest.git.createRef({
     owner: GH_CDS,
@@ -95,7 +93,6 @@ async function createPR(
   });
 
   const changedHelmfileUpdates = changesToHelmfile.filter(({ fileHasChanged }) => fileHasChanged);
-  const changedLambdaFileUpdates = changesToLambdaFiles.filter(({ fileHasChanged }) => fileHasChanged);
 
   const helmManifestUpdates = projects
     .map((project) => {
@@ -111,24 +108,6 @@ async function createPR(
       sha: releaseContent.sha,
       path: helmfileOverride,
       message: `Updated manifests to ${helmManifestUpdates}`,
-      content: newReleaseContentBlob,
-    })
-  }
-
-  const lambdaManifestUpdates = projects_lambdas
-    .map((project) => {
-      return `${project.repoName}:${project.shortSha}`;
-    })
-    .join(" and ");
-
-  for (const { manifestFile, releaseContent, newReleaseContentBlob } of changedLambdaFileUpdates) {
-    await octokit.rest.repos.createOrUpdateFileContents({
-      owner: GH_CDS,
-      repo: TARGET_REPO,
-      branch: branchName,
-      sha: releaseContent.sha,
-      path: manifestFile,
-      message: `Updated manifests to ${lambdaManifestUpdates}`,
       content: newReleaseContentBlob,
     })
   }
@@ -7504,7 +7483,6 @@ const repoDefaults = getRepoDefaults(TARGET_REPO, AWS_ECR_URL);
 const TITLE_PREFIX = getInput("TITLE_PREFIX", repoDefaults.titlePrefix);
 const PR_TEMPLATE_PATH = getInput("PR_TEMPLATE_PATH", repoDefaults.prTemplatePath);
 const PROJECTS = getJsonInput("PROJECTS", repoDefaults.projects);
-const PROJECTS_LAMBDAS = getJsonInput("PROJECTS_LAMBDAS", repoDefaults.projectsLambdas);
 
 // Shas ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
@@ -7525,10 +7503,6 @@ function shortSha(fullSha) {
     tag = tag.replaceAll("\"","");
     return tag;
   
-  }
-  
-  function getLambdaSha(imageName) {
-    return imageName.split(":").slice(-1)[0];
   }
   
   async function hydrateWithSHAs(projects) {
@@ -7556,45 +7530,10 @@ function shortSha(fullSha) {
       })
     );
   }
-  
-  async function hydrateLambdasWithSHAs(projects) {
-    return await Promise.all(
-      projects.map(async (project) => {
-        project.headSha = await getHeadSha(project.repoName);
-        project.shortSha = shortSha(project.headSha)
-        project.headUrl = getLatestImageUrl(
-          projects,
-          project.ecrName,
-          project.headSha
-        );
-  
-        const releaseContent = await getContents(
-          TARGET_REPO,
-          project.manifestFile
-        );
-  
-        const originalFileContents = Base64.decode(releaseContent.content)
-        const re = new RegExp(`${project.ecrName}:\\S*`, "g");
-        const matches = originalFileContents.match(re);
-        project.oldUrl = matches[0]
-        project.oldSha = getLambdaSha(project.oldUrl);
-        return project;
-      })
-    );
-  }
-  
-  function updateHelmfileSha(content,project) {
-    let re = new RegExp(String.raw`${project.helmfileTagKey}: "(.*?)"`, "g");
-    return content.replace(re, `${project.helmfileTagKey}: "${shortSha(project.headSha)}"`);
-  }
-  
-  function updateLambdaSha(content, project) {
-    return content.replace(`${project.ecrName}:${project.oldSha}`, `${project.ecrName}:${shortSha(project.headSha)}`)
-  }
 
 // HELMFILE ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-async function main(closePRsFirst, titlePrefix, projects, projects_lambdas) {
+async function main(closePRsFirst, titlePrefix, projects) {
   const prTemplate = await getContents(
     TARGET_REPO,
     PR_TEMPLATE_PATH
@@ -7602,7 +7541,6 @@ async function main(closePRsFirst, titlePrefix, projects, projects_lambdas) {
   const issueContent = Base64.decode(prTemplate.content);
 
   await hydrateWithSHAs(projects);
-  await hydrateLambdasWithSHAs(projects_lambdas);
 
   const reducer = (previous, project) => ({ ...previous, [project.helmfileOverride]: (previous[project.helmfileOverride] || []).concat(project) })
   const projectsForFiles = projects.reduce(reducer, {})
@@ -7626,33 +7564,9 @@ async function main(closePRsFirst, titlePrefix, projects, projects_lambdas) {
     return { helmfileOverride, newReleaseContentBlob, releaseContent, fileHasChanged }
   })
 
-  const lambdaReducer = (previous, project) => ({ ...previous, [project.manifestFile]: (previous[project.manifestFile] || []).concat(project) })
-  const lambdaProjectsForFiles = projects_lambdas.reduce(lambdaReducer, {})
-
-  var changesToLambdaFiles = Object.entries(lambdaProjectsForFiles).map(async ([manifestFile, projectsForFile]) => {
-
-    const releaseContent = await getContents(
-      TARGET_REPO,
-      manifestFile
-    );
-
-    var fileContents = Base64.decode(releaseContent.content)
-    projectsForFile.forEach((project) => {
-      fileContents = updateLambdaSha(fileContents, project)
-    })
-
-    const newReleaseContentBlob = Base64.encode(fileContents);
-    const fileHasChanged = newReleaseContentBlob.trim() != releaseContent.content.trim()
-
-    return { manifestFile, newReleaseContentBlob, releaseContent, fileHasChanged }
-  })
-
- 
   changesToHelmfile = await Promise.all(changesToHelmfile)
-  changesToLambdaFiles = await Promise.all(changesToLambdaFiles)
 
   const helmFilesHaveChanged = changesToHelmfile.some(({ fileHasChanged }) => fileHasChanged)
-  const lambdaFilesHaveChanged = changesToLambdaFiles.some(({ fileHasChanged }) => fileHasChanged)
   const extraFileChanges = [];
 
   if (TARGET_REPO === "notification-terraform") {
@@ -7664,17 +7578,15 @@ async function main(closePRsFirst, titlePrefix, projects, projects_lambdas) {
 
   const extraFilesHaveChanged = extraFileChanges.some(({ fileHasChanged }) => fileHasChanged)
 
-  if (helmFilesHaveChanged || lambdaFilesHaveChanged || extraFilesHaveChanged) {
+  if (helmFilesHaveChanged || extraFilesHaveChanged) {
     if (closePRsFirst) {
       await closePRs(titlePrefix);
     }
     await createPR(
       titlePrefix,
       projects,
-      projects_lambdas,
       issueContent,
       changesToHelmfile,
-      changesToLambdaFiles,
       extraFileChanges
     );
   } else {
@@ -7685,7 +7597,7 @@ async function main(closePRsFirst, titlePrefix, projects, projects_lambdas) {
 
 // Main execute ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-main(true, TITLE_PREFIX, PROJECTS, PROJECTS_LAMBDAS);
+main(true, TITLE_PREFIX, PROJECTS);
 
 })();
 

--- a/github.js
+++ b/github.js
@@ -69,17 +69,15 @@ function injectGeneratedContent(issueContent, logs) {
 
 async function createPR(
   titlePrefix,
-  projects, projects_lambdas,
+  projects,
   issueContent,
-  changesToHelmfile, changesToLambdaFiles,
+  changesToHelmfile,
   extraFileChanges,
-
 ) {
   const branchName = `release-${new Date().getTime()}`;
   const targetRepoSha = await getHeadSha(TARGET_REPO);
-  // pass in the projects and projects_lambdas so that the changes for all repos
-  // will be listed in the PR
-  const logs = await buildLogs([...projects, ...projects_lambdas], extraFileChanges);
+  // pass in the projects so that the changes for all repos will be listed in the PR
+  const logs = await buildLogs(projects, extraFileChanges);
 
   const ref = await octokit.rest.git.createRef({
     owner: GH_CDS,
@@ -89,7 +87,6 @@ async function createPR(
   });
 
   const changedHelmfileUpdates = changesToHelmfile.filter(({ fileHasChanged }) => fileHasChanged);
-  const changedLambdaFileUpdates = changesToLambdaFiles.filter(({ fileHasChanged }) => fileHasChanged);
 
   const helmManifestUpdates = projects
     .map((project) => {
@@ -105,24 +102,6 @@ async function createPR(
       sha: releaseContent.sha,
       path: helmfileOverride,
       message: `Updated manifests to ${helmManifestUpdates}`,
-      content: newReleaseContentBlob,
-    })
-  }
-
-  const lambdaManifestUpdates = projects_lambdas
-    .map((project) => {
-      return `${project.repoName}:${project.shortSha}`;
-    })
-    .join(" and ");
-
-  for (const { manifestFile, releaseContent, newReleaseContentBlob } of changedLambdaFileUpdates) {
-    await octokit.rest.repos.createOrUpdateFileContents({
-      owner: GH_CDS,
-      repo: TARGET_REPO,
-      branch: branchName,
-      sha: releaseContent.sha,
-      path: manifestFile,
-      message: `Updated manifests to ${lambdaManifestUpdates}`,
       content: newReleaseContentBlob,
     })
   }

--- a/index.js
+++ b/index.js
@@ -38,7 +38,6 @@ const repoDefaults = getRepoDefaults(TARGET_REPO, AWS_ECR_URL);
 const TITLE_PREFIX = getInput("TITLE_PREFIX", repoDefaults.titlePrefix);
 const PR_TEMPLATE_PATH = getInput("PR_TEMPLATE_PATH", repoDefaults.prTemplatePath);
 const PROJECTS = getJsonInput("PROJECTS", repoDefaults.projects);
-const PROJECTS_LAMBDAS = getJsonInput("PROJECTS_LAMBDAS", repoDefaults.projectsLambdas);
 
 // Shas ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
@@ -59,10 +58,6 @@ function shortSha(fullSha) {
     tag = tag.replaceAll("\"","");
     return tag;
   
-  }
-  
-  function getLambdaSha(imageName) {
-    return imageName.split(":").slice(-1)[0];
   }
   
   async function hydrateWithSHAs(projects) {
@@ -90,45 +85,10 @@ function shortSha(fullSha) {
       })
     );
   }
-  
-  async function hydrateLambdasWithSHAs(projects) {
-    return await Promise.all(
-      projects.map(async (project) => {
-        project.headSha = await getHeadSha(project.repoName);
-        project.shortSha = shortSha(project.headSha)
-        project.headUrl = getLatestImageUrl(
-          projects,
-          project.ecrName,
-          project.headSha
-        );
-  
-        const releaseContent = await getContents(
-          TARGET_REPO,
-          project.manifestFile
-        );
-  
-        const originalFileContents = Base64.decode(releaseContent.content)
-        const re = new RegExp(`${project.ecrName}:\\S*`, "g");
-        const matches = originalFileContents.match(re);
-        project.oldUrl = matches[0]
-        project.oldSha = getLambdaSha(project.oldUrl);
-        return project;
-      })
-    );
-  }
-  
-  function updateHelmfileSha(content,project) {
-    let re = new RegExp(String.raw`${project.helmfileTagKey}: "(.*?)"`, "g");
-    return content.replace(re, `${project.helmfileTagKey}: "${shortSha(project.headSha)}"`);
-  }
-  
-  function updateLambdaSha(content, project) {
-    return content.replace(`${project.ecrName}:${project.oldSha}`, `${project.ecrName}:${shortSha(project.headSha)}`)
-  }
 
 // HELMFILE ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-async function main(closePRsFirst, titlePrefix, projects, projects_lambdas) {
+async function main(closePRsFirst, titlePrefix, projects) {
   const prTemplate = await getContents(
     TARGET_REPO,
     PR_TEMPLATE_PATH
@@ -136,7 +96,6 @@ async function main(closePRsFirst, titlePrefix, projects, projects_lambdas) {
   const issueContent = Base64.decode(prTemplate.content);
 
   await hydrateWithSHAs(projects);
-  await hydrateLambdasWithSHAs(projects_lambdas);
 
   const reducer = (previous, project) => ({ ...previous, [project.helmfileOverride]: (previous[project.helmfileOverride] || []).concat(project) })
   const projectsForFiles = projects.reduce(reducer, {})
@@ -160,33 +119,9 @@ async function main(closePRsFirst, titlePrefix, projects, projects_lambdas) {
     return { helmfileOverride, newReleaseContentBlob, releaseContent, fileHasChanged }
   })
 
-  const lambdaReducer = (previous, project) => ({ ...previous, [project.manifestFile]: (previous[project.manifestFile] || []).concat(project) })
-  const lambdaProjectsForFiles = projects_lambdas.reduce(lambdaReducer, {})
-
-  var changesToLambdaFiles = Object.entries(lambdaProjectsForFiles).map(async ([manifestFile, projectsForFile]) => {
-
-    const releaseContent = await getContents(
-      TARGET_REPO,
-      manifestFile
-    );
-
-    var fileContents = Base64.decode(releaseContent.content)
-    projectsForFile.forEach((project) => {
-      fileContents = updateLambdaSha(fileContents, project)
-    })
-
-    const newReleaseContentBlob = Base64.encode(fileContents);
-    const fileHasChanged = newReleaseContentBlob.trim() != releaseContent.content.trim()
-
-    return { manifestFile, newReleaseContentBlob, releaseContent, fileHasChanged }
-  })
-
- 
   changesToHelmfile = await Promise.all(changesToHelmfile)
-  changesToLambdaFiles = await Promise.all(changesToLambdaFiles)
 
   const helmFilesHaveChanged = changesToHelmfile.some(({ fileHasChanged }) => fileHasChanged)
-  const lambdaFilesHaveChanged = changesToLambdaFiles.some(({ fileHasChanged }) => fileHasChanged)
   const extraFileChanges = [];
 
   if (TARGET_REPO === "notification-terraform") {
@@ -198,17 +133,15 @@ async function main(closePRsFirst, titlePrefix, projects, projects_lambdas) {
 
   const extraFilesHaveChanged = extraFileChanges.some(({ fileHasChanged }) => fileHasChanged)
 
-  if (helmFilesHaveChanged || lambdaFilesHaveChanged || extraFilesHaveChanged) {
+  if (helmFilesHaveChanged || extraFilesHaveChanged) {
     if (closePRsFirst) {
       await closePRs(titlePrefix);
     }
     await createPR(
       titlePrefix,
       projects,
-      projects_lambdas,
       issueContent,
       changesToHelmfile,
-      changesToLambdaFiles,
       extraFileChanges
     );
   } else {
@@ -219,4 +152,4 @@ async function main(closePRsFirst, titlePrefix, projects, projects_lambdas) {
 
 // Main execute ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-main(true, TITLE_PREFIX, PROJECTS, PROJECTS_LAMBDAS);
+main(true, TITLE_PREFIX, PROJECTS);


### PR DESCRIPTION
# Summary | Résumé

This pull request removes all logic related to handling lambda project updates from the deployment scripts. The code now only processes standard projects, simplifying the workflow and reducing complexity. The most important changes are:

**Removal of Lambda Project Handling:**

* All code related to the `PROJECTS_LAMBDAS` variable and lambda-specific functions (such as `hydrateLambdasWithSHAs`, `updateLambdaSha`, and the lambda manifest update logic) has been deleted from `index.js`. [[1]](diffhunk://#diff-e727e4bdf3657fd1d798edcd6b099d6e092f8573cba266154583a746bba0f346L41) [[2]](diffhunk://#diff-e727e4bdf3657fd1d798edcd6b099d6e092f8573cba266154583a746bba0f346L64-L67) [[3]](diffhunk://#diff-e727e4bdf3657fd1d798edcd6b099d6e092f8573cba266154583a746bba0f346L94-L139) [[4]](diffhunk://#diff-e727e4bdf3657fd1d798edcd6b099d6e092f8573cba266154583a746bba0f346L163-L189)
* The main execution flow and function signatures have been updated to remove references to lambda projects, ensuring only standard projects are processed. [[1]](diffhunk://#diff-e727e4bdf3657fd1d798edcd6b099d6e092f8573cba266154583a746bba0f346L201-L211) [[2]](diffhunk://#diff-e727e4bdf3657fd1d798edcd6b099d6e092f8573cba266154583a746bba0f346L222-R155)

**Simplification of Pull Request Creation:**

* The `createPR` function in `github.js` has been refactored to remove all lambda-related parameters and logic, focusing solely on standard project changes and Helmfile updates. [[1]](diffhunk://#diff-35d8b42b726adaa751252eb3ad98a7708f7be5ecf10ea6e637a42988b54d5a76L72-R80) [[2]](diffhunk://#diff-35d8b42b726adaa751252eb3ad98a7708f7be5ecf10ea6e637a42988b54d5a76L92) [[3]](diffhunk://#diff-35d8b42b726adaa751252eb3ad98a7708f7be5ecf10ea6e637a42988b54d5a76L112-L129)

These changes streamline the deployment process by focusing exclusively on standard projects and Helmfile updates, eliminating all special-case logic for lambda projects.

---

> Description en 1 à 3 phrases de la modification proposée, avec un lien vers le
> problème (« issue ») GitHub ou la fiche Trello, le cas échéant.

# Test instructions | Instructions pour tester la modification

> Sequential steps (1., 2., 3., ...) that describe how to test this change. This
> will help a developer test things out without too much detective work. Also,
> include any environmental setup steps that aren't in the normal README steps
> and/or any time-based elements that this requires.

---

> Étapes consécutives (1., 2., 3., …) qui décrivent la façon de tester la
> modification. Elles aideront les développeurs à faire des tests sans avoir à
> jouer au détective. Veuillez aussi inclure toutes les étapes de configuration
> de l’environnement qui ne font pas partie des étapes normales dans le fichier
> README et tout élément temporel requis.
